### PR TITLE
Change package name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vuetify",
+  "name": "@lzhoucs/vuetify",
   "version": "1.2.1",
   "author": {
     "name": "John Leider",


### PR DESCRIPTION
This allows people including myself to be able to use vuetify 1.2.x with added functionaility such as: https://github.com/lzhoucs/vuetify/pull/1 and upcoming https://github.com/lzhoucs/vuetify/pull/4

### How to use this package [@lzhoucs/vuetify](https://www.npmjs.com/package/@lzhoucs/vuetify):
* Modify `vuetify` package name in `package.json`
one way is to run the following commands:
```
npm uninstall vuetify
npm install @lzhoucs/vuetify --save
```
* Add an alias entry to webpack config so vuetify imports name doesn't have to be touched in the code. If you are using vue cli v3, the syntax looks like the following:
```
  configureWebpack: {
    resolve: {
      alias: {
        vuetify: '@lzhoucs/vuetify'
      }
    }
  }
```

