### PR TITLE
Add fixed columns table

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -72,6 +72,7 @@ export default {
   computed: {
     classes () {
       return {
+        'fixed-columns-table': this.getFixedColumnLeft(),
         'v-datatable v-table': true,
         'v-datatable--select-all': this.selectAll !== false,
         ...this.themeClasses
@@ -107,7 +108,11 @@ export default {
   },
 
   render (h) {
-    const tableOverflow = h(VTableOverflow, {}, [
+    const totalFixedWidth = this.getFixedColumnLeft()
+    const tableOverflow = h(VTableOverflow, {
+      // hard code to fix left columns with px unit for now
+      style: totalFixedWidth ? { marginLeft: `${totalFixedWidth}px` } : {}
+    }, [
       h('table', {
         'class': this.classes
       }, [

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -117,7 +117,9 @@ export default {
       ])
     ])
 
-    return h('div', [
+    return h('div', {
+      'class': 'v-datatable-root'
+    }, [
       tableOverflow,
       this.genActionsFooter()
     ])

--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -26,7 +26,7 @@ export default {
           `${groupPrefix}-col`,
           {
             [`${groupPrefix}-col--active`]: this.activeGroup[props.groupName],
-            'fixed-column': fixedColumnsCount,
+            'fixed-column': fixedColumnsCount
           }
         ],
         on: {
@@ -59,7 +59,6 @@ export default {
           class: 'v-datatable__expand-content',
           key: props.item[this.itemKey]
         }, [this.$scopedSlots.expand(props)])
-
         children.push(expand)
       }
 

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -27,7 +27,7 @@ export default {
 
         children = [this.hasTag(row, 'th') ? this.genTR(row) : row, this.genTProgress()]
       } else {
-        const row = this.headers.map((o, i) => this.genHeader(o, this.headerKey ? o[this.headerKey] : i))
+        const row = this.headers.map((o, i) => this.genHeader(o, this.headerKey ? o[this.headerKey] : i, i))
         const checkbox = this.$createElement(VCheckbox, {
           props: {
             dark: this.dark,
@@ -44,19 +44,25 @@ export default {
 
         children = [this.genTR(row), this.genTProgress()]
       }
-
+      // fixed column isn't compatible with the built in progress bar
+      this.getFixedColumnLeft() && children.pop()
       return this.$createElement('thead', [children])
     },
-    genHeader (header, key) {
+    genHeader (header, key, indx) {
       const array = [
         this.$scopedSlots.headerCell
           ? this.$scopedSlots.headerCell({ header })
           : header[this.headerText]
       ]
 
-      return this.$createElement('th', ...this.genHeaderData(header, array, key))
+      return this.$createElement('th', ...this.genHeaderData(header, array, key, indx))
     },
-    genHeaderData (header, children, key) {
+    getFixedColumnLeft (indx = this.headers.length) {
+      return this.headers
+        .filter((header, i) => i < indx && header.fixed === true )
+        .reduce((currentValue, header) => currentValue + (parseInt(header.width) || 0), 0)
+    },
+    genHeaderData (header, children, key, indx) {
       const classes = ['column']
       const data = {
         key,
@@ -75,6 +81,13 @@ export default {
         data.attrs['aria-label'] += ': Not sorted.' // TODO: Localization
       }
 
+      if (header.fixed === true) {
+        classes.push('fixed-column')
+        if (this.headers[indx + 1] && !this.headers[indx + 1].fixed) {
+          classes.push('last-fixed-column')
+        }
+        data.style = { left: `${this.getFixedColumnLeft(indx)}px` }
+      }
       classes.push(`text-xs-${header.align || 'left'}`)
       if (Array.isArray(header.class)) {
         classes.push(...header.class)

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -59,7 +59,7 @@ export default {
     },
     getFixedColumnLeft (indx = this.headers.length) {
       return this.headers
-        .filter((header, i) => i < indx && header.fixed === true )
+        .filter((header, i) => i < indx && header.fixed === true)
         .reduce((currentValue, header) => currentValue + (parseInt(header.width) || 0), 0)
     },
     genHeaderData (header, children, key, indx) {

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -135,6 +135,9 @@ theme(v-datatable, "v-datatable")
     padding: 0 !important
     cursor: pointer
 
+    &.fixed-column
+      left: 0
+      width: 100%
     &--active
       .v-datatable__group__expand-icon
         .v-icon

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -25,6 +25,9 @@ v-datatable($material)
 theme(v-datatable, "v-datatable")
 
 .v-datatable
+  &-root
+    position: relative;
+
   .v-input--selection-controls
     margin: 0
 

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -3,13 +3,17 @@
 
 /* Theme */
 v-table($material)
-  background-color: $material.cards
-  color: $material.text.primary
+  &, .fixed-column
+    background-color: $material.cards
+    color: $material.text.primary
+  .last-fixed-column
+    border-right: 1px solid rgba($material.fg-color, $material.divider-percent)
 
   thead
     tr
       &:first-child
-        border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
+        &, & .fixed-column
+          border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
 
     th
       color: rgba($material.text-color, $material.secondary-text-percent)
@@ -17,13 +21,15 @@ v-table($material)
   tbody
     tr
       &:not(:last-child)
-        border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
+        &, & .fixed-column
+          border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
 
       &[active]
         background: $material.table.active
 
       &:hover:not(.v-datatable__expand-row)
-        background: $material.table.hover
+        &, & .fixed-column
+          background: $material.table.hover
 
   tfoot
     tr
@@ -43,16 +49,22 @@ table.v-table
   width: 100%
   max-width: 100%
 
+  &.fixed-columns-table
+    table-layout: fixed
+
   thead, tbody
     td, th
       &:not(:nth-child(1)), &:first-child
         padding: 0 24px
+      &.fixed-column
+        position: absolute
+        display: flex
+        align-items: center
 
   thead
-    tr
-      height: 56px
 
     th
+      height: 56px
       font-weight: 500
       font-size: 12px
       transition: .3s $transition.swing
@@ -66,7 +78,7 @@ table.v-table
         width: 100%
 
   tbody
-    tr
+    tr, .fixed-column
       transition: background $primary-transition
       will-change: background
 

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -33,7 +33,6 @@ theme(v-table, "v-table")
 
 .v-table
   &__overflow
-    width: 100%
     overflow-x: auto
     overflow-y: hidden
 

--- a/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VDataTable.vue should match a snapshot - no data 1`] = `
 
-<div>
+<div class="v-datatable-root">
   <div class="v-table__overflow">
     <table class="v-datatable v-table theme--light">
       <thead>
@@ -181,7 +181,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
 
 exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
 
-<div>
+<div class="v-datatable-root">
   <div class="v-table__overflow">
     <table class="v-datatable v-table theme--light">
       <thead>
@@ -360,7 +360,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
 
 exports[`VDataTable.vue should match a snapshot - with data 1`] = `
 
-<div>
+<div class="v-datatable-root">
   <div class="v-table__overflow">
     <table class="v-datatable v-table theme--light">
       <thead>
@@ -541,7 +541,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
 
 exports[`VDataTable.vue should match a snapshot - with group 1`] = `
 
-<div>
+<div class="v-datatable-root">
   <div class="v-table__overflow">
     <table class="v-datatable v-table theme--light">
       <thead>
@@ -761,7 +761,7 @@ exports[`VDataTable.vue should match a snapshot - with group 1`] = `
 
 exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 1`] = `
 
-<div>
+<div class="v-datatable-root">
   <div class="v-table__overflow">
     <table class="v-datatable v-table theme--light">
       <thead>


### PR DESCRIPTION
This adds fixed columns support to vuetify tables and grouping table(see: https://github.com/lzhoucs/vuetify/pull/1)

Demo: https://codepen.io/lzhoucs/pen/dqZvXr

This is an attempt for resolving: https://github.com/vuetifyjs/vuetify/issues/4652, part of https://github.com/vuetifyjs/vuetify/issues/2787.

The idea of fixed column table was originated from: potentially https://github.com/vuetifyjs/vuetify/issues/1547

Currently the feature only supports left columns being fixed. The intention of this feature, along with 
https://github.com/lzhoucs/vuetify/pull/1 is so we have something to use for our projects while the table is being rewritten in https://github.com/vuetifyjs/vuetify/pull/3833.

Until https://github.com/vuetifyjs/vuetify/pull/3833 is done, to use this version of fixed-columns feature, you have to:
* Change vuetify package name. See https://github.com/lzhoucs/vuetify/pull/2
* Add `fixed: true` to the headers prop to indicate the current column is a fixed column, e.g:
```
        headers: [
            { text: "Dessert (100g serving)", value: "name", width: '200px', fixed: true },
            { text: "Calories", value: "calories", width: '200px', fixed: true },
            { text: "Fat (g)", value: "fat", width: '300px' },
            { text: "Carbs (g)", value: "carbs", width: '300px' },
            { text: "Protein (g)", value: "protein", width: '300px' },
            { text: "Iron (%)", value: "iron", width: '300px' }
```
Note `width` is no longer optional on fixed columns.
