### PR TITLE
Fix v-icon issue.

### DIFF
--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -144,7 +144,7 @@ theme(datatable, "datatable")
       width: 100%
     &--active
       .v-datatable__group__expand-icon
-        .v-icon
+        .icon
           transform: rotate(-180deg)
 
   &-content


### PR DESCRIPTION
This fixes `v-icon` issue introduced in https://github.com/lzhoucs/vuetify/pull/6. The root cause is `icon` instead of `v-icon` class is available in `1.0.x` release.