### PR TITLE
Add collapseAll/expandAll methods.

### DIFF
--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -9,6 +9,14 @@ export default {
 
       return this.$createElement('tbody', children)
     },
+    collapseAll () {
+      this.activeGroup = {}
+    },
+    expandAll () {
+      for (const group in this.activeGroup) {
+        this.activeGroup[group] = true
+      }
+    },
     genGroupRow (props) {
       const groupPrefix = 'v-datatable__group'
       const expandIcon = this.$createElement('div', {
@@ -111,6 +119,9 @@ export default {
           const groupRow = this.genGroupRow(groupProps)
           rows.push(groupRow)
           groupIndex++
+          if (!this.activeGroup.hasOwnProperty(currentGroup)) {
+            this.$set(this.activeGroup, currentGroup, false)
+          }
         }
 
         if (this.$scopedSlots.group && !this.activeGroup[currentGroup]) {


### PR DESCRIPTION
This PR adds  `collapseAll/expandAll` methods.

These two methods are intended to be called by a parent component when all
groups need to be collapsed/expanded from a parent component.

See updated demo: https://codepen.io/lzhoucs/pen/aadaJx