### PR TITLE
Return early when items does not have to be sorted.

### DIFF
--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -85,7 +85,7 @@ export default {
     customSort: {
       type: Function,
       default: (items, ...sortSpecs) => {
-        if (!sortSpecs.length) return items
+        if (!sortSpecs.length || sortSpecs.every(([index, isDescending]) => !index)) return items
 
         return items.sort((a, b) => compareFunc(a, b, 0))
 


### PR DESCRIPTION
This guarantees the items to not be messed up by a potentially unstable sort
implemented by browser.

