### PR TITLE
Bug fix 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lzhoucs/vuetify",
-  "version": "1.2.8-modified.5",
+  "version": "1.2.8-modified.6",
   "author": {
     "name": "John Leider",
     "email": "john@vuetifyjs.com"

--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -10,9 +10,12 @@ export default {
       return this.$createElement('tbody', children)
     },
     collapseAll () {
+      this._groupExpanded = this.groupExpanded
+      this.groupExpanded = false
       this.activeGroup = {}
     },
     expandAll () {
+      this.groupExpanded = this._groupExpanded
       for (const group in this.activeGroup) {
         this.activeGroup[group] = true
       }


### PR DESCRIPTION
The newly added flag `groupExpanded` in https://github.com/lzhoucs/vuetify/pull/26 does not play well with expandAll/CollapseAll methods. This is the fix.